### PR TITLE
ARM: Improve FPU context handling

### DIFF
--- a/os/rt/ports/ARM/chcore.h
+++ b/os/rt/ports/ARM/chcore.h
@@ -193,6 +193,7 @@ struct port_extctx {
   regarm_t              spsr_irq;
   regarm_t              lr_irq;
 #if defined(ARM_FPU)
+  regarm_t              reserved;
   regarm_t              fpscr;
   regarm_t              d[48]; // d0-d7, d16-d31
 #endif
@@ -212,6 +213,7 @@ struct port_extctx {
 struct port_intctx {
 #if defined(ARM_FPU)
   regarm_t              d[16]; // d8-d15
+  regarm_t              reserved;
 #endif
   regarm_t              r4;
   regarm_t              r5;
@@ -325,7 +327,7 @@ struct context {
 #define port_switch(ntp, otp) {                                             \
   register struct port_intctx *r13 asm ("r13");                             \
   if ((stkalign_t *)(r13 - 1) < otp->p_stklimit)                            \
-  chSysHalt("stack overflow");                                              \
+    chSysHalt("stack overflow");                                            \
   _port_switch_arm(ntp, otp);                                               \
 }
 #else

--- a/os/rt/ports/ARM/chcore.h
+++ b/os/rt/ports/ARM/chcore.h
@@ -192,6 +192,10 @@ typedef void *regarm_t;
 struct port_extctx {
   regarm_t              spsr_irq;
   regarm_t              lr_irq;
+#if defined(ARM_FPU)
+  regarm_t              fpscr;
+  regarm_t              d[48]; // d0-d7, d16-d31
+#endif
   regarm_t              r0;
   regarm_t              r1;
   regarm_t              r2;
@@ -207,8 +211,7 @@ struct port_extctx {
  */
 struct port_intctx {
 #if defined(ARM_FPU)
-  regarm_t              fpscr;
-  regarm_t              d[64];
+  regarm_t              d[16]; // d8-d15
 #endif
   regarm_t              r4;
   regarm_t              r5;
@@ -236,15 +239,6 @@ struct context {
 /*===========================================================================*/
 
 /**
- * @brief   FPU-specific context initialization
- */
-#if defined(ARM_FPU)
-#define ARM_FPU_SETUP_CONTEXT(tp) { (tp)->p_ctx.r13->fpscr = (regarm_t)(0); }
-#else
-#define ARM_FPU_SETUP_CONTEXT(tp)
-#endif
-
-/**
  * @brief   Platform dependent part of the @p chThdCreateI() API.
  * @details This code usually setup the context switching frame represented
  *          by an @p port_intctx structure.
@@ -256,7 +250,6 @@ struct context {
   (tp)->p_ctx.r13->r4 = (regarm_t)(pf);                                     \
   (tp)->p_ctx.r13->r5 = (regarm_t)(arg);                                    \
   (tp)->p_ctx.r13->lr = (regarm_t)(_port_thread_start);                     \
-  ARM_FPU_SETUP_CONTEXT(tp);                                                \
 }
 
 /**

--- a/os/rt/ports/ARM/compilers/GCC/chcoreasm.s
+++ b/os/rt/ports/ARM/compilers/GCC/chcoreasm.s
@@ -132,6 +132,7 @@ _port_switch_arm:
                 stmfd   sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 
 #if defined(ARM_FPU)
+                stmfd   sp!, {r4}               // Push R4=RESERVED.
                 vpush   {d8-d15}
 #endif
                 str     sp, [r1, #12]
@@ -139,6 +140,7 @@ _port_switch_arm:
 
 #if defined(ARM_FPU)
                 vpop    {d8-d15}
+                ldmfd   sp!, {r4}               // Pop R4=RESERVED.
 #endif
 
 #if defined(THUMB_PRESENT)
@@ -187,10 +189,10 @@ Irq_Handler:
                 stmfd   sp!, {r0-r3, r12, lr}
 
 #if defined(ARM_FPU)
-                fmrx    r0, fpscr
+                fmrx    r1, fpscr
                 vpush   {d16-d31}
                 vpush   {d0-d7}
-                push    {r0}
+                stmfd   sp!, {r0, r1}           // Push R0=RESERVED, R1=FPSCR.
 #endif
 
                 // Save the IRQ conditions
@@ -258,10 +260,10 @@ _irq_handler_done:
 
                 // Pop caller-saved registers from System stack
 #if defined(ARM_FPU)
-                pop     {r0}
+                ldmfd   sp!, {r0, r1}           // Pop R0=RESERVED, R1=FPSCR.
                 vpop    {d0-d7}
                 vpop    {d16-d31}
-                fmxr    fpscr, r0
+                fmxr    fpscr, r1
 #endif
 
                 ldmfd   sp!, {r0-r3, r12, lr}

--- a/os/rt/ports/ARM/compilers/GCC/chcoreasm.s
+++ b/os/rt/ports/ARM/compilers/GCC/chcoreasm.s
@@ -181,6 +181,9 @@ _port_switch_arm:
                 .code   32
                 .global Irq_Handler
 Irq_Handler:
+
+                // Push caller-saved registers to System stack
+                msr     CPSR_c, #MODE_SYS | I_BIT
                 stmfd   sp!, {r0-r3, r12, lr}
 
 #if defined(ARM_FPU)
@@ -190,6 +193,15 @@ Irq_Handler:
                 push    {r0}
 #endif
 
+                // Save the IRQ conditions
+                msr     CPSR_c, #MODE_IRQ | I_BIT
+                mrs     r0, SPSR
+                mov     r1, lr
+                msr     CPSR_c, #MODE_SYS | I_BIT
+                stmfd   sp!, {r0, r1}           // Push R0=SPSR_IRQ, R1=LR_IRQ.
+
+                // Call ISR in IRQ mode
+                msr     CPSR_c, #MODE_IRQ | I_BIT
                 ldr     r0, =ARM_IRQ_VECTOR_REG
                 ldr     r0, [r0]
 #if !defined(THUMB_NO_INTERWORKING)
@@ -205,35 +217,11 @@ _irq_ret_arm:
                 bx      lr
                 .code   32
 #endif /* defined(THUMB_NO_INTERWORKING) */
+                msr     CPSR_c, #MODE_SYS | I_BIT
+
+                // Skip context switch if ISR returns false
                 cmp     r0, #0
-
-#if defined(ARM_FPU)
-                pop     {r0}
-                vpop    {d0-d7}
-                vpop    {d16-d31}
-                fmxr    fpscr, r0
-#endif
-
-                ldmfd   sp!, {r0-r3, r12, lr}
-                subeqs  pc, lr, #4              // No reschedule, returns.
-
-                // Now the frame is created in the system stack, the IRQ
-                // stack is empty.
-                msr     CPSR_c, #MODE_SYS | I_BIT
-                stmfd   sp!, {r0-r3, r12, lr}
-
-#if defined(ARM_FPU)
-                fmrx    r0, fpscr
-                vpush   {d16-d31}
-                vpush   {d0-d7}
-                push    {r0}
-#endif
-
-                msr     CPSR_c, #MODE_IRQ | I_BIT
-                mrs     r0, SPSR
-                mov     r1, lr
-                msr     CPSR_c, #MODE_SYS | I_BIT
-                stmfd   sp!, {r0, r1}           // Push R0=SPSR, R1=LR_IRQ.
+                beq     _irq_handler_done
 
                 // Context switch.
 #if defined(THUMB_NO_INTERWORKING)
@@ -260,13 +248,15 @@ _irq_ret_arm:
 #endif
 #endif /* !defined(THUMB_NO_INTERWORKING) */
 
-                // Re-establish the IRQ conditions again.
-                ldmfd   sp!, {r0, r1}           // Pop R0=SPSR, R1=LR_IRQ.
+_irq_handler_done:
+                // Re-establish the IRQ conditions
+                ldmfd   sp!, {r0, r1}           // Pop R0=SPSR_IRQ, R1=LR_IRQ.
                 msr     CPSR_c, #MODE_IRQ | I_BIT
                 msr     SPSR_fsxc, r0
                 mov     lr, r1
                 msr     CPSR_c, #MODE_SYS | I_BIT
 
+                // Pop caller-saved registers from System stack
 #if defined(ARM_FPU)
                 pop     {r0}
                 vpop    {d0-d7}


### PR DESCRIPTION
- Preserve caller-saved FPU registers for the duration of `IRQ_Handler`
- Only preserve callee-saved FPU registers in context switch handler
- Only push registers once to SYS stack in `IRQ_Handler`
- Observe 8-byte boundary for FPU registers and SPI
