### PR TITLE
HAL: make Zynq PAL thread-safe

### DIFF
--- a/os/hal/ports/ZYNQ7000/pal_lld.c
+++ b/os/hal/ports/ZYNQ7000/pal_lld.c
@@ -44,6 +44,19 @@
 /* Driver local functions.                                                   */
 /*===========================================================================*/
 
+static void mask_write(ioportid_t port, ioportmask_t mask, ioportmask_t bits) {
+
+  if (mask & 0xFFFFU) {
+    GPIO->MASK_DATA[port].LSW = ((~(mask & 0xFFFFU) & 0xFFFFU) << 16) |
+                                ((bits & 0xFFFFU)              << 0);
+  }
+
+  if ((mask >> 16) & 0xFFFFU) {
+    GPIO->MASK_DATA[port].MSW = ((~((mask >> 16) & 0xFFFFU) & 0xFFFFU) << 16) |
+                                (((bits >> 16) & 0xFFFFU)              << 0);
+  }
+}
+
 /*===========================================================================*/
 /* Driver interrupt handlers.                                                */
 /*===========================================================================*/
@@ -102,6 +115,59 @@ ioportmask_t _pal_lld_readlatch(ioportid_t port) {
  */
 void _pal_lld_writeport(ioportid_t port, ioportmask_t bits) {
   GPIO->DATA[port] = bits;
+}
+
+/**
+ * @brief   Sets a bits mask on a I/O port.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be ORed on the specified port
+ *
+ * @notapi
+ */
+void _pal_lld_setport(ioportid_t port, ioportmask_t bits) {
+  mask_write(port, bits, 0xFFFFFFFFU);
+}
+
+/**
+ * @brief   Clears a bits mask on a I/O port.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be cleared on the specified port
+ *
+ * @notapi
+ */
+void _pal_lld_clearport(ioportid_t port, ioportmask_t bits) {
+  mask_write(port, bits, 0x0U);
+}
+
+/**
+ * @brief   Toggles a bits mask on a I/O port.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be XORed on the specified port
+ *
+ * @notapi
+ */
+void _pal_lld_toggleport(ioportid_t port, ioportmask_t bits) {
+  mask_write(port, bits, ~GPIO->DATA[port]);
+}
+
+/**
+ * @brief   Writes a group of bits.
+ *
+ * @param[in] port      port identifier
+ * @param[in] mask      group mask, a logic AND is performed on the
+ *                      output data
+ * @param[in] bits      bits to be written. Values exceeding the group
+ *                      width are masked.
+ *
+ * @notapi
+ */
+void _pal_lld_writegroup(ioportid_t port,
+                         ioportmask_t mask,
+                         ioportmask_t bits) {
+  mask_write(port, mask, bits);
 }
 
 /**
@@ -167,6 +233,34 @@ void _pal_lld_setgroupmode(ioportid_t port,
       mask >>= 1;
     } while (mask);
   }
+}
+
+/**
+ * @brief   Writes a logic state on an output pad.
+ *
+ * @param[in] port      port identifier
+ * @param[in] pad       pad number within the port
+ * @param[in] bit       logic value, the value must be @p PAL_LOW or
+ *                      @p PAL_HIGH
+ *
+ * @notapi
+ */
+void _pal_lld_writepad(ioportid_t port, uint8_t pad, uint8_t bit) {
+    mask_write(port, PAL_PORT_BIT(pad), (bit & 1U) << pad);
+}
+
+/**
+ * @brief   Toggles a pad logic state.
+ *
+ * @param[in] port      port identifier
+ * @param[in] pad       pad number within the port
+ *
+ * @notapi
+ */
+void _pal_lld_togglepad(ioportid_t port, uint8_t pad) {
+
+  uint8_t bit = (GPIO->DATA[port] & GPIO_PIN_Msk(pad)) ? 0 : 1;
+  _pal_lld_writepad(port, pad, bit);
 }
 
 #endif /* HAL_USE_PAL == TRUE */

--- a/os/hal/ports/ZYNQ7000/pal_lld.h
+++ b/os/hal/ports/ZYNQ7000/pal_lld.h
@@ -216,6 +216,51 @@ typedef uint32_t ioportid_t;
 #define pal_lld_writeport(port, bits) _pal_lld_writeport(port, bits)
 
 /**
+ * @brief   Sets a bits mask on a I/O port.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be ORed on the specified port
+ *
+ * @notapi
+ */
+#define pal_lld_setport(port, bits) _pal_lld_setport(port, bits)
+
+/**
+ * @brief   Clears a bits mask on a I/O port.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be cleared on the specified port
+ *
+ * @notapi
+ */
+#define pal_lld_clearport(port, bits) _pal_lld_clearport(port, bits)
+
+/**
+ * @brief   Toggles a bits mask on a I/O port.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be XORed on the specified port
+ *
+ * @notapi
+ */
+#define pal_lld_toggleport(port, bits) _pal_lld_toggleport(port, bits)
+
+/**
+ * @brief   Writes a group of bits.
+ *
+ * @param[in] port      port identifier
+ * @param[in] mask      group mask, a logic AND is performed on the
+ *                      output data
+ * @param[in] offset    group bit offset within the port
+ * @param[in] bits      bits to be written. Values exceeding the group
+ *                      width are masked.
+ *
+ * @notapi
+ */
+#define pal_lld_writegroup(port, mask, offset, bits)                        \
+  _pal_lld_writegroup(port, mask << offset, bits)
+
+/**
  * @brief   Pads group mode setup.
  * @details This function programs a pads group belonging to the same port
  *          with the specified mode.
@@ -231,6 +276,48 @@ typedef uint32_t ioportid_t;
 #define pal_lld_setgroupmode(port, mask, offset, mode)                      \
   _pal_lld_setgroupmode(port, mask << offset, mode)
 
+/**
+ * @brief   Writes a logic state on an output pad.
+ *
+ * @param[in] port      port identifier
+ * @param[in] pad       pad number within the port
+ * @param[in] bit       logic value, the value must be @p PAL_LOW or
+ *                      @p PAL_HIGH
+ *
+ * @notapi
+ */
+#define pal_lld_writepad(port, pad, bit) _pal_lld_writepad(port, pad, bit)
+
+/**
+ * @brief   Sets a pad logic state to @p PAL_HIGH.
+ *
+ * @param[in] port      port identifier
+ * @param[in] pad       pad number within the port
+ *
+ * @notapi
+ */
+#define pal_lld_setpad(port, pad) _pal_lld_writepad(port, pad, PAL_HIGH)
+
+/**
+ * @brief   Clears a pad logic state to @p PAL_LOW.
+ *
+ * @param[in] port      port identifier
+ * @param[in] pad       pad number within the port
+ *
+ * @notapi
+ */
+#define pal_lld_clearpad(port, pad) _pal_lld_writepad(port, pad, PAL_LOW)
+
+/**
+ * @brief   Toggles a pad logic state.
+ *
+ * @param[in] port      port identifier
+ * @param[in] pad       pad number within the port
+ *
+ * @notapi
+ */
+#define pal_lld_togglepad(port, pad) _pal_lld_togglepad(port, pad)
+
 #if !defined(__DOXYGEN__)
 extern const PALConfig pal_default_config;
 #endif
@@ -242,9 +329,17 @@ extern "C" {
   ioportmask_t _pal_lld_readport(ioportid_t port);
   ioportmask_t _pal_lld_readlatch(ioportid_t port);
   void _pal_lld_writeport(ioportid_t port, ioportmask_t bits);
+  void _pal_lld_setport(ioportid_t port, ioportmask_t bits);
+  void _pal_lld_clearport(ioportid_t port, ioportmask_t bits);
+  void _pal_lld_toggleport(ioportid_t port, ioportmask_t bits);
+  void _pal_lld_writegroup(ioportid_t port,
+                           ioportmask_t mask,
+                           ioportmask_t bits);
   void _pal_lld_setgroupmode(ioportid_t port,
                              ioportmask_t mask,
                              iomode_t mode);
+  void _pal_lld_writepad(ioportid_t port, uint8_t pad, uint8_t bit);
+  void _pal_lld_togglepad(ioportid_t port, uint8_t pad);
 #ifdef __cplusplus
 }
 #endif

--- a/os/hal/ports/ZYNQ7000/zynq7000.h
+++ b/os/hal/ports/ZYNQ7000/zynq7000.h
@@ -102,7 +102,7 @@ typedef enum {
   /* IRQ IDs 36 is reserved */
   IRQ_ID_PMU_CPU0 =           37,
   IRQ_ID_PMU_CPU1 =           38,
-  IRQ_ID_XACD =               39,
+  IRQ_ID_XADC =               39,
   IRQ_ID_DEVC =               40,
   IRQ_ID_SWDT =               41,
   IRQ_ID_TTC0_0 =             42,


### PR DESCRIPTION
Use `MASK_DATA` registers for atomic set/clear. Pin configuration is still _not_ atomic and must be protected.

/cc @axlan @swift-nav/firmware 
