### PR TITLE
HAL: fix ZYNQ WDT stop

### DIFF
--- a/os/hal/ports/ZYNQ7000/wdg_lld.c
+++ b/os/hal/ports/ZYNQ7000/wdg_lld.c
@@ -128,7 +128,9 @@ void wdg_lld_start(WDGDriver *wdgp) {
 void wdg_lld_stop(WDGDriver *wdgp) {
 
   (void)wdgp;
-  PRV_WDT->CONTROL &= ~PRV_WDT_CONTROL_ENABLE_Msk;
+  PRV_WDT->DISABLE = PRV_WDT_DISABLE_VAL_1;
+  PRV_WDT->DISABLE = PRV_WDT_DISABLE_VAL_2;
+  PRV_WDT->CONTROL = 0;
 }
 
 /**


### PR DESCRIPTION
It appears that the ARM documentation is incorrect or incomplete. Clearing the `CONTROL.ENABLE` bit has no effect unless the proper sequence is written to the `DISABLE` register.

/cc @swift-nav/firmware 