### PR TITLE
Add chSysHaltExtra [ESD-881] [ESD-914]

### DIFF
--- a/os/rt/include/chdebug.h
+++ b/os/rt/include/chdebug.h
@@ -28,6 +28,11 @@
 #ifndef _CHDEBUG_H_
 #define _CHDEBUG_H_
 
+/* Two macros ensures any macro passed will
+ * be expanded before being stringified */
+#define STRINGIFY_DETAIL(x) #x
+#define STRINGIFY(x) STRINGIFY_DETAIL(x)
+
 /*===========================================================================*/
 /* Module constants.                                                         */
 /*===========================================================================*/
@@ -164,14 +169,17 @@ typedef struct {
  * @api
  */
 #if !defined(chDbgCheck)
-#define chDbgCheck(c) do {                                                  \
-  /*lint -save -e506 -e774 [2.1, 14.3] Can be a constant by design.*/       \
-  if (CH_DBG_ENABLE_CHECKS != FALSE) {                                      \
-    if (!(c)) {                                                             \
-  /*lint -restore*/                                                         \
-      chSysHalt(__func__);                                                  \
-    }                                                                       \
-  }                                                                         \
+#define chDbgCheck(c) do {                                                     \
+  /*lint -save -e506 -e774 [2.1, 14.3] Can be a constant by design.*/          \
+  if (CH_DBG_ENABLE_CHECKS != FALSE) {                                         \
+    if (!(c)) {                                                                \
+  /*lint -restore*/                                                            \
+      /* Should use chThdGetSelfX(), but chdebug.h is before chthreads.h in */ \
+      /* ch.h, so this is a shortcut to minimize changes..                  */ \
+      chSysHaltExtra(                                                          \
+           ch.rlist.r_current->p_name, __func__, __LINE__, STRINGIFY(c));      \
+    }                                                                          \
+  }                                                                            \
 } while (false)
 #endif /* !defined(chDbgCheck) */
 
@@ -190,14 +198,14 @@ typedef struct {
  * @api
  */
 #if !defined(chDbgAssert)
-#define chDbgAssert(c, r) do {                                              \
-  /*lint -save -e506 -e774 [2.1, 14.3] Can be a constant by design.*/       \
-  if (CH_DBG_ENABLE_ASSERTS != FALSE) {                                     \
-    if (!(c)) {                                                             \
-  /*lint -restore*/                                                         \
-      chSysHalt(__func__);                                                  \
-    }                                                                       \
-  }                                                                         \
+#define chDbgAssert(c, r) do {                                                 \
+  /*lint -save -e506 -e774 [2.1, 14.3] Can be a constant by design.*/          \
+  if (CH_DBG_ENABLE_ASSERTS != FALSE) {                                        \
+    if (!(c)) {                                                                \
+  /*lint -restore*/                                                            \
+      chSysHaltExtra(ch.rlist.r_current->p_name, __func__, __LINE__, r);       \
+    }                                                                          \
+  }                                                                            \
 } while (false)
 #endif /* !defined(chDbgAssert) */
 /** @} */

--- a/os/rt/include/chsys.h
+++ b/os/rt/include/chsys.h
@@ -276,6 +276,10 @@ extern "C" {
 #endif
   void chSysInit(void);
   void chSysHalt(const char *reason);
+  void chSysHaltExtra(const char *thd,
+                      const char *function,
+                      int line,
+                      const char *reason);
   bool chSysIntegrityCheckI(unsigned testmask);
   void chSysTimerHandlerI(void);
   syssts_t chSysGetStatusAndLockX(void);

--- a/os/rt/src/chsys.c
+++ b/os/rt/src/chsys.c
@@ -185,6 +185,28 @@ void chSysHalt(const char *reason) {
   }
 }
 
+void chSysHaltExtra(const char *thd,
+                    const char *func,
+                    int line,
+                    const char *reason) {
+
+  port_disable();
+
+#if defined(CH_CFG_SYSTEM_HALT_HOOK) || defined(__DOXYGEN__)
+  if (thd == NULL) {
+    thd = "unknown";
+  }
+  CH_CFG_SYSTEM_HALT_HOOK("%s:%s:%d: %s", thd, func, line, reason);
+#endif
+
+  /* Pointing to the passed message.*/
+  ch.dbg.panic_msg = reason;
+
+  /* Harmless infinite loop.*/
+  while (true) {
+  }
+}
+
 /**
  * @brief   System integrity check.
  * @details Performs an integrity check of the important ChibiOS/RT data


### PR DESCRIPTION
Aim is to make ChibiOS system halt more informative. Any ideas how to bring this even further are welcome.

Issues:
https://swift-nav.atlassian.net/browse/ESD-881
https://swift-nav.atlassian.net/browse/ESD-914
Depends:
https://github.com/swift-nav/piksi_firmware_private/pull/2524